### PR TITLE
Bugfix/globals

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -98,10 +98,11 @@ class Server {
 	}
 
 	start () {
+		
 		this.app.set('port', ( this.config.port || 8888 ));
 		this.app.listen( this.app.get('port'), function() {
-			this._globals.LOGGER.info(`App is running on port ${ this.app.get('port') }`);
-		});
+			this.global.LOGGER.info(`App is running on port ${ this.app.get('port') }`);
+		}.bind(this));
 	}
 
 }

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -100,7 +100,7 @@ class Server {
 	start () {
 		this.app.set('port', ( this.config.port || 8888 ));
 		this.app.listen( this.app.get('port'), function() {
-			this.global.LOGGER.info(`App is running on port ${ this.app.get('port') }`);
+			this._globals.LOGGER.info(`App is running on port ${ this.app.get('port') }`);
 		});
 	}
 


### PR DESCRIPTION
Closes #5 

Also it is possible to use an arrow function
```javascript
this.app.listen( this.app.get('port'), () => {
     this._globals.LOGGER.info(`App is running on port ${ this.app.get('port') }`);
});
```

or use a variable to keep the ```this``` reference