### PR TITLE
Change parameters on routers

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -78,9 +78,9 @@ class Server {
 			this.app.use( methodOR('X-HTTP-Method-Override') );
 		}
 		if ( this.config.routers && this.config.routers.length > 0  ) {
-			this.config.routers.forEach( function( router ) {
-				require(router.relpath)(globals);
-			});
+			this.config.routers.forEach(function (router) {
+				require(router.relpath)(this.app);
+			}.bind(this));
 		}
 		if ( this.config.templates && this.config.templates.length > 0 ) {
 			// 		const nunjucks = require ('nunjucks');


### PR DESCRIPTION
Closes #7 

Base on Routers definitions:

```javascript
function registerRouters(app, auth) {
   app.use('/api/v1/auth', require('./auth')());
};
```

First argument has to be the **app** , instead the globals variable was passed as argument